### PR TITLE
Fix for Python >=3.8 dll discovery

### DIFF
--- a/blendermodule/VisualSPHysics.py
+++ b/blendermodule/VisualSPHysics.py
@@ -26,7 +26,12 @@ bl_info = {
 import bpy, sys, math, re, os, time, array, ctypes, bmesh, mathutils
 import xml.etree.ElementTree as ET
 
- 
+if sys.version_info[1]>=8 and os.name == 'nt':
+    if "VTK_DLL_PATH" in os.environ:
+        os.add_dll_directory(os.environ['VTK_DLL_PATH'])
+    else:
+        raise ValueError('Python 3.8 and higher requires VTK_DLL_PATH to be set in environment')
+
 import vtkimporter 
 import diffuseparticles
 


### PR DESCRIPTION
Since Python 2.8 DLL discovery on Windows has changed and thus the add-on fails to install as Python cannot load VTK DLLs.
This change introduces an environment variable VTK_DLL_PATH that needs to explicity point to the direcotry with VTK.
The varablie should be set to something like: C:\\Program Files (x86)\\VTK\\bin (or wherever users VTK installation is located).
This should remediate the bugs with DLL not loading on Windows in later versions of Blender.
Works with Blender 3.4 and Python 3.10